### PR TITLE
Add Garlic Decompiler to Improve Pitest Framework Efficiency

### DIFF
--- a/fwlib/fwlib.go
+++ b/fwlib/fwlib.go
@@ -17,6 +17,12 @@ type Runnable interface {
 	Run()
 }
 
+// Decompiling interfaces describes Framework instances that have to decompile binaries in order to extract mutants.
+type Decompiling interface {
+	// SetDecompiler sets the decompiler that is being used.
+	SetDecompiler()
+}
+
 type FWConfig interface {
 	Init() interface{}
 	Load(yml []byte) (bool, error)

--- a/fws/pitest/pitest.go
+++ b/fws/pitest/pitest.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/SecretSheppy/marv/fwlib"
+	"github.com/SecretSheppy/marv/pkg/garlic"
 	"github.com/SecretSheppy/marv/pkg/mutations"
 	"github.com/SecretSheppy/marv/pkg/vineflower"
 	"github.com/aymanbagabas/go-udiff"
@@ -25,6 +26,7 @@ type YamlConfig struct {
 	SrcCodePath  string `yaml:"src-code-path"`
 	SrcClassPath string `yaml:"src-class-path"`
 	MutClassPath string `yaml:"mut-class-path"`
+	Decompiler   string `yaml:"decompiler"`
 }
 
 // YamlWrapper used to load the pitest configuration from the .marv.yml file.
@@ -98,7 +100,16 @@ type Pitest struct {
 }
 
 func NewPitest() *Pitest {
-	return &Pitest{yml: &YamlWrapper{}, dcomp: &vineflower.Vineflower{}}
+	return &Pitest{yml: &YamlWrapper{}}
+}
+
+func (p *Pitest) SetDecompiler() {
+	switch strings.ToLower(p.yml.Cfg.Decompiler) {
+	case "garlic":
+		p.dcomp = &garlic.Garlic{}
+	default:
+		p.dcomp = &vineflower.Vineflower{}
+	}
 }
 
 func (p *Pitest) Meta() *fwlib.Meta {
@@ -157,6 +168,8 @@ func (p *Pitest) TransformResults() error {
 	}
 	indexBar.Finish()
 	fmt.Println()
+
+	log.Info().Msgf("%s - using %s", p.Meta().Name, p.dcomp)
 
 	transformBar := progressbar.NewOptions(
 		len(msMap),

--- a/internal/cmds/export.go
+++ b/internal/cmds/export.go
@@ -25,6 +25,10 @@ func exportCommand() {
 	_, activeFws := getConfigAndFws()
 
 	for _, fw := range activeFws {
+		if decompiling, ok := fw.(fwlib.Decompiling); ok {
+			decompiling.SetDecompiler()
+		}
+
 		if err := fw.TransformResults(); err != nil {
 			log.Error().Err(err)
 			os.Exit(1)

--- a/internal/cmds/root.go
+++ b/internal/cmds/root.go
@@ -36,6 +36,10 @@ func rootCommand() {
 	_, activeFws := getConfigAndFws()
 
 	for _, fw := range activeFws {
+		if decompiling, ok := fw.(fwlib.Decompiling); ok {
+			decompiling.SetDecompiler()
+		}
+
 		_ = fw.TransformResults()
 	}
 

--- a/pkg/garlic/garlic.go
+++ b/pkg/garlic/garlic.go
@@ -1,0 +1,28 @@
+package garlic
+
+import (
+	"os"
+	"os/exec"
+	"path"
+)
+
+type Garlic struct{}
+
+func (g *Garlic) GarlicPath() string {
+	dir := os.Getenv("LIB_PATH")
+	if dir == "" {
+		wd, _ := os.Getwd()
+		dir = path.Join(wd, "lib")
+	}
+	return path.Join(dir, "garlic")
+}
+
+func (g *Garlic) Decompile(p string) ([]byte, error) {
+	cmd := exec.Command(g.GarlicPath(), p)
+	cmd.Env = os.Environ()
+	return cmd.Output()
+}
+
+func (g *Garlic) String() string {
+	return g.GarlicPath()
+}

--- a/pkg/vineflower/vineflower.go
+++ b/pkg/vineflower/vineflower.go
@@ -23,8 +23,12 @@ func (v *Vineflower) Help() ([]byte, error) {
 	return cmd.Output()
 }
 
-func (v *Vineflower) Decompile(path string) ([]byte, error) {
-	cmd := exec.Command("java", "-jar", v.JarPath(), "--log-level=error", path)
+func (v *Vineflower) Decompile(p string) ([]byte, error) {
+	cmd := exec.Command("java", "-jar", v.JarPath(), "--log-level=error", p)
 	cmd.Env = os.Environ()
 	return cmd.Output()
+}
+
+func (v *Vineflower) String() string {
+	return v.JarPath()
 }


### PR DESCRIPTION
hugely, hugely faster than the current vineflower implementation. Whilst it does produce slightly worse results in my opinion, there is not much in it and the speed advantage is huge.

Users will have to install their os specific garlic library in order to use this. vineflower still default.