### PR TITLE
refactor: moved ReadLines into Framework spec

### DIFF
--- a/fwlib/fwlib.go
+++ b/fwlib/fwlib.go
@@ -29,8 +29,6 @@ type FWConfig interface {
 	Init() interface{}
 	// Load unmarshals the yml data into the struct if it exists, and returns true if any configuration was loaded.
 	Load(yml []byte) (bool, error)
-	// SourceCodeDir returns the path to the source code directory.
-	SourceCodeDir() string
 }
 
 // Framework defines what methods an extension must have in order to interact with the marv system.
@@ -45,4 +43,6 @@ type Framework interface {
 	TransformResults() error
 	// Mutations returns the mutations in the marv format. Returns nil if TransformResults has not been called.
 	Mutations() mutations.Mutations
+	// ReadLines returns the lines of the specified file
+	ReadLines(file string) ([]string, error)
 }

--- a/fws/mockfw/mockfw.go
+++ b/fws/mockfw/mockfw.go
@@ -16,10 +16,6 @@ func (y *YamlWrapper) Load(_ []byte) (bool, error) {
 	return false, nil
 }
 
-func (y *YamlWrapper) SourceCodeDir() string {
-	return ""
-}
-
 // MockFW is a framework that is only for use when testing methods that require a fwlib.Framework as a parameter. It
 // allows you to set the mutations that are returned and has a Meta value, but otherwise returns nil or false in all
 // cases.

--- a/fws/mockfw/mockfw.go
+++ b/fws/mockfw/mockfw.go
@@ -50,3 +50,7 @@ func (m *MockFW) TransformResults() error {
 func (m *MockFW) Mutations() mutations.Mutations {
 	return m.Muts
 }
+
+func (m *MockFW) ReadLines(_ string) ([]string, error) {
+	return nil, nil
+}

--- a/fws/mutest_rs/mutest_rs.go
+++ b/fws/mutest_rs/mutest_rs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SecretSheppy/marv/fwlib"
 	"github.com/SecretSheppy/marv/internal/languages"
 	"github.com/SecretSheppy/marv/internal/mutations"
+	"github.com/SecretSheppy/marv/pkg/fio"
 	"github.com/rs/zerolog/log"
 	"github.com/schollz/progressbar/v3"
 	"gopkg.in/yaml.v3"
@@ -40,10 +41,6 @@ func (y *YamlWrapper) Load(yml []byte) (bool, error) {
 		return false, nil
 	}
 	return y.Cfg.Src != "" || y.Cfg.JsonDir != "", nil
-}
-
-func (y *YamlWrapper) SourceCodeDir() string {
-	return y.Cfg.Src
 }
 
 // Evaluation marshals to evaluation.json from the mutest output data
@@ -217,4 +214,8 @@ func getMutationStatus(id int, ev *Evaluation) (mutations.Status, error) {
 
 func (m *MutestRS) Mutations() mutations.Mutations {
 	return m.ms
+}
+
+func (m *MutestRS) ReadLines(file string) ([]string, error) {
+	return fio.ReadLines(path.Join(m.yml.Cfg.Src, file))
 }

--- a/fws/pitest/pitest.go
+++ b/fws/pitest/pitest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SecretSheppy/marv/fwlib"
 	"github.com/SecretSheppy/marv/internal/languages"
 	"github.com/SecretSheppy/marv/internal/mutations"
+	"github.com/SecretSheppy/marv/pkg/fio"
 	"github.com/rs/zerolog/log"
 	"github.com/schollz/progressbar/v3"
 	"gopkg.in/yaml.v3"
@@ -44,10 +45,6 @@ func (y *YamlWrapper) Load(yml []byte) (bool, error) {
 		return false, nil
 	}
 	return y.Cfg.XmlPath != "" || y.Cfg.SrcCodePath != "" || y.Cfg.SrcClassPath != "" || y.Cfg.MutClassPath != "", nil
-}
-
-func (y *YamlWrapper) SourceCodeDir() string {
-	return y.Cfg.SrcCodePath
 }
 
 // FileMutations stores all mutants of the same file against the string of the full file path.
@@ -199,6 +196,10 @@ func (p *Pitest) TransformResults() error {
 
 func (p *Pitest) Mutations() mutations.Mutations {
 	return p.ms
+}
+
+func (p *Pitest) ReadLines(file string) ([]string, error) {
+	return fio.ReadLines(path.Join(p.yml.Cfg.SrcCodePath, file))
 }
 
 func streamlineMutation(m *Mutation, starts, ends *mutations.Range) *mutations.Mutation {

--- a/internal/html/renderer.go
+++ b/internal/html/renderer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/SecretSheppy/marv/fwlib"
 	"github.com/SecretSheppy/marv/internal/mutations"
 	"github.com/SecretSheppy/marv/internal/review"
-	"github.com/SecretSheppy/marv/pkg/fio"
 	"github.com/google/uuid"
 )
 
@@ -157,8 +156,7 @@ func (r *Renderer) RenderTree() ([]byte, error) {
 }
 
 func (r *Renderer) renderCode(framework fwlib.Framework, filePath string, conflicts mutations.Conflicts, config *codeRendererConfig) ([]byte, string, error) {
-	absolutePath := path.Join(framework.Yaml().SourceCodeDir(), filePath)
-	lines, err := fio.ReadLines(absolutePath)
+	lines, err := framework.ReadLines(filePath)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
This is in anticipation of adding the `go-mutesting` framework, which (like many frameworks) exports the source files in its json report. Thus it makes sense to have a `ReadLines` function in the Framework spec so that frameworks could call `fio.ReadLines` or instead return the lines from the json report etc...