### PR TITLE
refactor: extracted meta objects as variables

### DIFF
--- a/fws/mutest_rs/mutest_rs.go
+++ b/fws/mutest_rs/mutest_rs.go
@@ -17,6 +17,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var meta = fwlib.Meta{
+	Name:     "mutest-rs",
+	Language: languages.Rust,
+	URL:      "https://github.com/zalanlevai/mutest-rs",
+}
+
 // YamlConfig represents Mutest-RS yml config data.
 type YamlConfig struct {
 	Run     string `yaml:"run"`
@@ -96,11 +102,7 @@ func NewMutestRS() *MutestRS {
 }
 
 func (m *MutestRS) Meta() *fwlib.Meta {
-	return &fwlib.Meta{
-		Name:     "mutest-rs",
-		Language: languages.Rust,
-		URL:      "https://github.com/zalanlevai/mutest-rs",
-	}
+	return &meta
 }
 
 func (m *MutestRS) Yaml() fwlib.FWConfig {

--- a/fws/pitest/pitest.go
+++ b/fws/pitest/pitest.go
@@ -17,7 +17,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const FWName = "Pitest"
+var meta = fwlib.Meta{
+	Name:     "Pitest",
+	Language: languages.Java,
+	URL:      "https://pitest.org/",
+}
 
 // YamlConfig represents Pitest's yml config data.
 type YamlConfig struct {
@@ -115,11 +119,7 @@ func (p *Pitest) SetDecompiler() {
 }
 
 func (p *Pitest) Meta() *fwlib.Meta {
-	return &fwlib.Meta{
-		Name:     FWName,
-		Language: languages.Java,
-		URL:      "https://pitest.org/",
-	}
+	return &meta
 }
 
 func (p *Pitest) Yaml() fwlib.FWConfig {

--- a/fws/pitest/transform.go
+++ b/fws/pitest/transform.go
@@ -77,7 +77,7 @@ func (e *transformError) Error() string {
 }
 
 func (e *transformError) log() {
-	log.Error().Err(e.Err).Str("file", e.File).Str("decompiler", e.Decompiler).Msgf("%s - %s", FWName, e.Message)
+	log.Error().Err(e.Err).Str("file", e.File).Str("decompiler", e.Decompiler).Msgf("%s - %s", meta.Name, e.Message)
 }
 
 func newTransformError(err error, message, file, decompiler string) transformError {


### PR DESCRIPTION
prevents continuous creation of new meta objects