### PR TITLE
fix: resolved issue with not being able to type into review fields

### DIFF
--- a/web/scripts/review.js
+++ b/web/scripts/review.js
@@ -66,6 +66,10 @@ async function reviewInputBlurEvent(event) {
  * @param {KeyboardEvent} event
  */
 function keydownEvent(event) {
+    if (!['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown'].includes(event.key)) {
+        return
+    }
+
     hideAllEmptyReviews();
 
     if (lastActiveMutationID === "") {


### PR DESCRIPTION
The review key listener was preventing you from typing because it was always trying to focus a null element.