### PR TITLE
refactor: add printing of url for each framework

### DIFF
--- a/internal/cmds/list.go
+++ b/internal/cmds/list.go
@@ -2,8 +2,10 @@ package cmds
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/SecretSheppy/marv/fwlib"
 	"github.com/SecretSheppy/marv/fws"
@@ -20,9 +22,12 @@ var listCmd = &cobra.Command{
 		slices.SortFunc(frameworks, func(a, b fwlib.Framework) int {
 			return strings.Compare(a.Meta().Name, b.Meta().Name)
 		})
+		w := new(tabwriter.Writer)
+		w.Init(os.Stdout, 0, 8, 0, '\t', 0)
 		for _, fw := range frameworks {
-			fmt.Println(fw.Meta().Name)
+			fmt.Fprintf(w, "%s\t%s\n", fw.Meta().Name, fw.Meta().URL)
 		}
+		w.Flush()
 	},
 }
 


### PR DESCRIPTION
Now prints the following instead of just the frameworks name:

```
Mull            https://mull-project.com/
Pitest          https://pitest.org/
cargo-mutants   https://github.com/sourcefrog/cargo-mutants
generic         https://github.com/SecretSheppy/marv
go-mutesting    https://github.com/zimmski/go-mutesting
infection       https://https://infection.github.io/
mewt            https://github.com/trailofbits/mewt
mutant          https://github.com/mbj/mutant
mutest-rs       https://github.com/zalanlevai/mutest-rs
stryker-js      https://github.com/stryker-mutator/stryker-net
stryker-net     https://github.com/stryker-mutator/stryker-net
stryker4s       https://github.com/stryker-mutator/stryker4s
```