### PR TITLE
Push new state on column sort

### DIFF
--- a/web/scripts/sortable-tables.js
+++ b/web/scripts/sortable-tables.js
@@ -1,47 +1,64 @@
 'use strict';
 
+const DATA_ASCENDING = 'data-ascending'
+
 function dataValue(element, item) {
     let value = element.childNodes.item(item).getAttribute('data-value')
     return value === 'NaN' ? -1 : value;
 }
 
-function shouldReverse(titles, column) {
-    let data = titles.childNodes.item(column).getAttribute('data-asc');
-    titles.childNodes.forEach(node => node.setAttribute('data-asc', ''))
-    if (data == null || data === '' || data === 'true') {
-        titles.childNodes.item(column).setAttribute('data-asc', 'false');
+function isAscending(titles, column) {
+    let data = titles.childNodes.item(column).getAttribute(DATA_ASCENDING);
+    titles.childNodes.forEach(node => node.setAttribute(DATA_ASCENDING, ''))
+    if (data == null || data === '' || data === 'false') {
+        titles.childNodes.item(column).setAttribute(DATA_ASCENDING, 'true');
         return false;
     }
-    titles.childNodes.item(column).setAttribute('data-asc', 'true');
+    titles.childNodes.item(column).setAttribute(DATA_ASCENDING, 'false');
     return true;
 }
 
-function sortTableByColumn(event) {
-    let table = event.target.closest('table');
+function sortTableByColumn(table, column) {
     let tbody = table.childNodes.item(0);
     let elements = [...tbody.childNodes];
     let titles = elements.splice(0, 1)[0];
-
-    let column = event.target.closest('div.sortable').getAttribute('data-column');
-    let reverse = shouldReverse(titles, column);
-    console.log(reverse)
+    let ascending = isAscending(titles, column);
     let sorted = elements.sort((a, b) => {
-        if (reverse) {
-            return dataValue(a, column) - dataValue(b, column);
+        if (ascending) {
+            return dataValue(b, column) - dataValue(a, column);
         }
-        return dataValue(b, column) - dataValue(a, column);
+        return dataValue(a, column) - dataValue(b, column);
     });
-
     let cloned = tbody.cloneNode();
     cloned.appendChild(titles)
     for (let i = 0; i < sorted.length; i++) {
         cloned.appendChild(sorted[i])
     }
     table.replaceChild(cloned, tbody);
+    return ascending
+}
+
+function sortTableByColumnOnClick(event) {
+    let table = event.target.closest('table');
+    let column = event.target.closest('div.sortable').getAttribute('data-column');
+    let ascending = sortTableByColumn(table, column)
+    history.pushState({}, "", "?column=" + column + "&ascending=" + ascending)
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    let params = new URLSearchParams(window.location.search)
+    let column = params.get('column')
+    let ascending = params.get('ascending')
+    if (column != null && ascending != null) {
+        let table = document.querySelector('.generic-table');
+        let th = table.childNodes.item(0) // tbody
+            .childNodes.item(0) // tr:first-child
+            .childNodes.item(column) // th for column: column
+        th.setAttribute(DATA_ASCENDING, ascending)
+        sortTableByColumn(table, column)
+    }
+
     document.querySelectorAll('th > div.sortable').forEach(element => {
-        element.addEventListener('click', sortTableByColumn)
+        element.addEventListener('click', sortTableByColumnOnClick)
     })
 })


### PR DESCRIPTION
allows a user to return to their previous sorting without having to click the table again. the order won't be exactly preserved, but that isn't a huge problem.