### PR TITLE
Add description codeblock formatting

### DIFF
--- a/fws/infection/infection.go
+++ b/fws/infection/infection.go
@@ -1,6 +1,8 @@
 package infection
 
 import (
+	"strings"
+
 	"github.com/SecretSheppy/marv/fwlib"
 	"github.com/SecretSheppy/marv/internal/mtelib"
 	"github.com/SecretSheppy/marv/internal/mutations"
@@ -66,8 +68,19 @@ func (i *Infection) TransformResults() error {
 	i.mte.Transform(bar)
 	fwlib.FinishProgressbar(bar)
 
+	i.correctDescriptionCodeBlocks()
 	i.correctLineLengthOverhangs()
 	return nil
+}
+
+func (i *Infection) correctDescriptionCodeBlocks() {
+	for _, conflicts := range i.mte.Mutations() {
+		for _, conflict := range conflicts {
+			for _, mutation := range conflict.Mutations {
+				mutation.Description = strings.ReplaceAll(mutation.Description, "```php", "```")
+			}
+		}
+	}
 }
 
 // see infection/README.md as to why this method is necessary and for visual examples of it in practise.

--- a/internal/html/code.go
+++ b/internal/html/code.go
@@ -287,7 +287,7 @@ func (r *codeRenderer) renderAllMutationData(buff *bytes.Buffer, m *mutations.Mu
 	}
 	buff.WriteString("</p>")
 
-	buff.WriteString(fmt.Sprintf("<p><span class=\"data-type\">Description:</span> %s</p>", html.EscapeString(m.Description)))
+	buff.WriteString(fmt.Sprintf("<p><span class=\"data-type\">Description:</span> %s</p>", formatDescription(html.EscapeString(m.GetDescription()))))
 
 	// Mutation Operator
 	buff.WriteString(fmt.Sprintf("<p><span class=\"data-type\">Mutation Operator:</span> %s</p>", html.EscapeString(m.Operation)))

--- a/internal/html/code.go
+++ b/internal/html/code.go
@@ -265,7 +265,7 @@ func (r *codeRenderer) renderInnerHighlight(pre, diff, post, class string) (stri
 func (r *codeRenderer) renderMutationHeader(buff *bytes.Buffer, m *mutations.Mutation) {
 	buff.WriteString("<tr><td colspan=\"100%\"><div class=\"mutation-header\">")
 	buff.WriteString(m.Status.IconWithText())
-	buff.WriteString(fmt.Sprintf("<p class=\"mutation-description\">%s</p>", html.EscapeString(m.GetDescription())))
+	buff.WriteString(fmt.Sprintf("<p class=\"mutation-description\">%s</p>", formatDescription(html.EscapeString(m.GetDescription()))))
 	buff.WriteString("<div class=\"spacer\"></div><div class=\"mutation-options\">")
 	buff.WriteString("<button class=\"review-btn option-btn\"><img class=\"icon\" src=\"" + getIconURL(r.shared.document.Theme, "pen-solid.svg") + "\" alt=\"pen icon\" />Review</button>")
 	buff.WriteString(fmt.Sprintf("<a title=\"view mutation %s\" href=\"/%s/mutant/%s?m=%s#%s\">%.7s</a>", m.ID, r.config.Framework.Meta().Name, r.config.FilePath, m.ID, m.ID, m.ID))

--- a/internal/html/description.go
+++ b/internal/html/description.go
@@ -39,6 +39,7 @@ func formatDescription(description string) string {
 				open = false
 				continue
 			}
+			tail = 0
 			fallthrough
 		case open:
 			code.Write(d[i : i+1])

--- a/internal/html/description.go
+++ b/internal/html/description.go
@@ -1,0 +1,50 @@
+package html
+
+import (
+	"bytes"
+	"strings"
+)
+
+const backtick = 96
+
+func formatDescription(description string) string {
+	d := []byte(description)
+	var (
+		head, tail int
+		open       bool
+		desc       strings.Builder
+		code       bytes.Buffer
+	)
+	for i := 0; i < len(d); i++ {
+		b := d[i]
+		switch {
+		case b == backtick && head == 0:
+			for j := i; j < len(d) && d[j] == backtick; j++ {
+				head++
+			}
+			i += head - 1
+			open = true
+		case b == backtick:
+			for j := i; j < len(d) && d[j] == backtick; j++ {
+				tail++
+			}
+			i += tail - 1
+			if head == tail {
+				desc.WriteString(`<span class="inline-code">`)
+				desc.Write(code.Bytes())
+				desc.WriteString(`</span>`)
+				code.Reset()
+				head = 0
+				tail = 0
+				open = false
+				continue
+			}
+			fallthrough
+		case open:
+			code.Write(d[i : i+1])
+		default:
+			desc.Write(d[i : i+1])
+		}
+	}
+	return desc.String()
+}

--- a/internal/html/description_test.go
+++ b/internal/html/description_test.go
@@ -1,0 +1,53 @@
+package html
+
+import "testing"
+
+func TestDescriptionFormatter(t *testing.T) {
+	tests := []struct {
+		Name, Description, Expected string
+	}{
+		{
+			Name:        "test no backticks yields no codeblocks",
+			Description: "replaced return statement with null",
+			Expected:    "replaced return statement with null",
+		},
+		{
+			Name:        "test single backticks yields a codeblock",
+			Description: "replaced `45` with null",
+			Expected:    `replaced <span class="inline-code">45</span> with null`,
+		},
+		{
+			Name:        "test multiple sets of single backticks yields multiple codeblocks",
+			Description: "replaced `45` with `null`",
+			Expected:    `replaced <span class="inline-code">45</span> with <span class="inline-code">null</span>`,
+		},
+		{
+			Name:        "test triple backticks yields a codeblock",
+			Description: "replaced ```45``` with null",
+			Expected:    `replaced <span class="inline-code">45</span> with null`,
+		},
+		{
+			Name:        "test multiple sets of triple backticks yields multiple codeblocks",
+			Description: "replaced ```45``` with ```null```",
+			Expected:    `replaced <span class="inline-code">45</span> with <span class="inline-code">null</span>`,
+		},
+		{
+			Name:        "test mixed codeblock generation with single backticks and triple backticks",
+			Description: "replaced ```45``` with `null`",
+			Expected:    `replaced <span class="inline-code">45</span> with <span class="inline-code">null</span>`,
+		},
+		{
+			Name:        "test single backticks inside tripple backticks",
+			Description: "replaced ```def `x` with``` with null",
+			Expected:    "replaced <span class=\"inline-code\">def `x` with</span> with null",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			formatted := formatDescription(test.Description)
+			if formatted != test.Expected {
+				t.Errorf("got %q, want %q", formatted, test.Expected)
+			}
+		})
+	}
+}

--- a/internal/themes/themes.go
+++ b/internal/themes/themes.go
@@ -69,11 +69,12 @@ type UIColors struct {
 	Accent              UIColorsAccent     `json:"accent"`
 	Statistics          UIColorsStatistics `json:"statistics"`
 	LinkColor           string             `json:"link-color"`
+	CodeBlockBackground string             `json:"code-block-background"`
 }
 
 func (u UIColors) CSS() string {
-	return fmt.Sprintf("--main-bg:%s;--main-secondary-bg:%s;--main-hover-bg:%s;%s%s--link-fg:%s;",
-		u.PrimaryBackground, u.SecondaryBackground, u.HoverBackground, u.Accent.CSS(), u.Statistics.CSS(), u.LinkColor)
+	return fmt.Sprintf("--main-bg:%s;--main-secondary-bg:%s;--main-hover-bg:%s;%s%s--link-fg:%s;--code-inline-bg:%s;",
+		u.PrimaryBackground, u.SecondaryBackground, u.HoverBackground, u.Accent.CSS(), u.Statistics.CSS(), u.LinkColor, u.CodeBlockBackground)
 }
 
 type UIComponents struct {

--- a/web/styles/code.css
+++ b/web/styles/code.css
@@ -215,6 +215,13 @@
     color: var(--main-text-fg);
 }
 
+.inline-code {
+    font-family: monospace;
+    background: var(--code-inline-bg);
+    border-radius: 4px;
+    padding: 0 4px;
+}
+
 @media screen and (min-width: 1400px) {
     .mutation-description {
         max-width: 650px;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -40,6 +40,7 @@
     --code-line-height: 24px;
     --code-font-size: 0.83rem;
     --code-line-number-color: #b0b0b0;
+    --code-inline-bg: #313233;
 
     --diff-remove: #492e2eb8;
     --diff-remove-dark: #571e1e;

--- a/web/themes/darcula.json
+++ b/web/themes/darcula.json
@@ -26,7 +26,8 @@
                 "mediocre": "#FFA500B2",
                 "negative": "#D25353"
             },
-            "link-color": "#1395FF"
+            "link-color": "#1395FF",
+            "code-block-background": "#313233"
         },
         "components": {
             "divider": "solid 1px #323232",

--- a/web/themes/dracula.json
+++ b/web/themes/dracula.json
@@ -26,7 +26,8 @@
                 "mediocre": "#F1FA8C",
                 "negative": "#FF5555"
             },
-            "link-color": "#8BE9FD"
+            "link-color": "#8BE9FD",
+            "code-block-background": "#313652"
         },
         "components": {
             "divider": "solid 1px #44475A",

--- a/web/themes/light.json
+++ b/web/themes/light.json
@@ -26,7 +26,8 @@
                 "mediocre": "#F0AD4C",
                 "negative": "#CF3232"
             },
-            "link-color": "#0B79D0"
+            "link-color": "#0B79D0",
+            "code-block-background": "#D7DFE7"
         },
         "components": {
             "divider": "solid 1px #E5E7EB",


### PR DESCRIPTION
Adds codeblock formatting for descriptions:

<img width="1416" height="650" alt="image" src="https://github.com/user-attachments/assets/45f6e9ed-5d81-4fa0-a2ba-dcf7eca518ba" />

Closes #47 