### PR TITLE
fix: only loop through number of highlighted lines

### DIFF
--- a/internal/html/code.go
+++ b/internal/html/code.go
@@ -111,7 +111,7 @@ func (r *codeRenderer) render() ([]byte, error) {
 
 	var buff bytes.Buffer
 	buff.WriteString("<table id=\"code-table\" class=\"bg code\">")
-	for i := 0; i < len(r.lines); i++ {
+	for i := 0; i < len(r.highlighted); i++ {
 		if len(rendered) > 0 {
 			if conflict := rendered[0]; conflict.start == i {
 				buff.WriteString(conflict.render)


### PR DESCRIPTION
chroma does not give blank trailing lines a full line span, so looping over lines and pulling from highlighted was causing some files to fail to render, as the last line from lines had been "deleted" in syntax highlighting by chroma.